### PR TITLE
Fix ComplianceService method call and improve type safety

### DIFF
--- a/src/app/api/analytics/rcsa/route.ts
+++ b/src/app/api/analytics/rcsa/route.ts
@@ -1,10 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { withApiMiddleware } from '@/lib/api/middleware';
 import { db } from '@/lib/db';
+import { AuthenticatedRequest } from '@/types/api';
 
 export const GET = withApiMiddleware(
-  async (req: NextRequest) => {
-    const user = (req as any).user;
+  async (req: AuthenticatedRequest) => {
+    const user = req.user;
     
     if (!user || !user.organizationId) {
       return NextResponse.json(

--- a/src/app/api/compliance/frameworks/route.ts
+++ b/src/app/api/compliance/frameworks/route.ts
@@ -1,10 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { withApiMiddleware } from '@/lib/api/middleware';
-import ComplianceService from '@/services/ComplianceService';
+import { complianceService } from '@/services/ComplianceService';
+import { AuthenticatedRequest } from '@/types/api';
 
 export const GET = withApiMiddleware(
-  async (req: NextRequest) => {
-    const user = (req as any).user;
+  async (req: AuthenticatedRequest) => {
+    const user = req.user;
     
     if (!user || !user.organizationId) {
       return NextResponse.json(
@@ -14,7 +15,7 @@ export const GET = withApiMiddleware(
     }
 
     try {
-      const frameworks = await ComplianceService.getFrameworks(user.organizationId);
+      const frameworks = await complianceService.getFrameworks(user.organizationId);
 
       return NextResponse.json({
         success: true,


### PR DESCRIPTION
## Summary
- Fixed incorrect static method call to ComplianceService instance method
- Improved type safety by removing unsafe type assertions

## Changes
- Use `complianceService` singleton instance instead of static `ComplianceService.getFrameworks()`
- Replace `(req as any).user` with properly typed `AuthenticatedRequest`

🤖 Generated with [Claude Code](https://claude.ai/code)